### PR TITLE
Add support for connecting to HTTPS servers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,7 @@ hyper = "0.12"
 futures = "0.1"
 lazy_static = "1.3"
 unicase = "2.3"
+hyper-tls = { version = "0.3.2", optional = true }
+
+[features]
+https = ["hyper-tls"]


### PR DESCRIPTION
 * Add the `https` feature which condionally compiles the `hyper-tls` crate
 * Abstract HTTP(S) client building to a helper function with two versions: One which uses the `hyper-tls` `HttpsConnector` connector, and one which uses the default built-in `HttpConnector`
 * Update documentation on how to enable HTTPS support